### PR TITLE
Extend to include DESC reviewers and individual acknowledgements

### DIFF
--- a/acknowledgments.tex
+++ b/acknowledgments.tex
@@ -1,4 +1,19 @@
+% This paper has undergone internal review in the LSST Dark Energy Science Collaboration. % REQUIRED
+% The internal reviewers were \ldots. % Optional but recommended
+% 
+% Standard papers only: author contribution statements. For examples, see http://blogs.nature.com/nautilus/2007/11/post_12.html
 %
-This manuscript has been authored by Fermi Research Alliance, LLC under Contract No. DE-AC02-07CH11359 with the U.S. Department of Energy, Office of Science, Office of High Energy Physics. 
+% This work used TBD kindly provided by Not-A-DESC Member and benefitted from comments by Another Non-DESC person.
+%
+% Standard papers only: A.B.C. acknowledges support from grant 1234 from ... 
+%   NB (PJM). SLAC researchers need not list the DOE contract number as it appears in the standard acknowledgements below already.
+%
+%
+%
+% \input{desc-tex/ack/standard}
+%
 The DESC acknowledges ongoing support from the Institut National de Physique Nucl\'eaire et de Physique des Particules in France; the Science \& Technology Facilities Council in the United Kingdom; and the Department of Energy, the National Science Foundation, and the LSST Corporation in the United States.  DESC uses resources of the IN2P3 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la Recherche Scientifique; the National Energy Research Scientific Computing Center, a DOE Office of Science User Facility supported by the Office of Science of the U.S.\ Department of Energy under Contract No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BIS National E-infrastructure capital grants; and the UK particle physics grid, supported by the GridPP Collaboration.  This work was performed in part under DOE Contract DE-AC02-76SF00515.
 % 
+% This work used some telescope which is operated/funded by some agency or consortium or foundation ...
+% 
+% We acknowledge the use of An-External-Tool-like-NED-or-ADS.


### PR DESCRIPTION
Left the review part commented for now, to avoid confusion about the draft's status. Thought it useful to give people a place to put their individual acks. I followed the template at https://github.com/LSSTDESC/desc-tex/tree/master/ack - hope this helps!